### PR TITLE
fix: prevent double-destroy error when using !stop command

### DIFF
--- a/src/services/AudioService.ts
+++ b/src/services/AudioService.ts
@@ -138,12 +138,14 @@ export class AudioService implements IAudioService {
   cleanup(guildId: string): void {
     const state = this.guildStates.get(guildId);
     if (state) {
+      // Delete first to prevent re-entrant calls from the Destroyed event
+      this.guildStates.delete(guildId);
+
       state.isPlaying = false;
       if (state.ffmpegProcess) {
         state.ffmpegProcess.kill();
       }
       state.connection.destroy();
-      this.guildStates.delete(guildId);
       logger.info({ guildId }, "Cleaned up resources");
     }
   }


### PR DESCRIPTION
## Summary

- Fixes the "Cannot destroy VoiceConnection - it has already been destroyed" error when using `!stop`
- Moves `guildStates.delete()` before `connection.destroy()` to prevent re-entrant cleanup calls

## Root Cause

The `cleanup()` method was calling `connection.destroy()` before removing the state from the map. This triggered the `VoiceConnectionStatus.Destroyed` event synchronously, which called `cleanup()` again while the first call was still executing, resulting in a double-destroy error.

## Test plan

- [x] Run `!play` to start streaming
- [x] Run `!stop` to stop streaming
- [x] Verify no error is thrown in the logs

Fixes #16

🤖 Generated with [Claude Code](https://claude.ai/code)