### PR TITLE
feat: auto-stop bot when all users leave voice channel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ Copy `.env.example` to `.env` and configure:
 - `DISCORD_TOKEN` - Your Discord bot token
 - `DATABASE_URL` - PostgreSQL connection string
 - `ADMIN_ROLE_ID` - (Optional) Role ID for admin commands
+- `LOG_LEVEL` - (Optional) Logging level: `debug`, `info`, `warn`, `error` (default: `info`)
 
 ## Architecture
 
@@ -48,16 +49,52 @@ src/
 ├── controllers/          # Command routing
 ├── commands/             # Individual command handlers
 ├── views/                # Response formatting
-└── utils/                # Utility functions (permissions)
+└── utils/                # Utility functions (permissions, logging)
+
+.github/
+├── ISSUE_TEMPLATE/       # Issue templates
+├── workflows/            # GitHub Actions CI/CD
+├── pull_request_template.md  # PR template
+└── dependabot.yml        # Dependency updates config
 ```
 
 ### Key Components
 
-- `AudioService`: Manages voice connections and audio playback
+- `AudioService`: Manages voice connections and audio playback with automatic reconnection
 - `StreamService`: Creates FFmpeg processes for audio streaming
-- `StationService`: CRUD operations for radio stations
-- `CommandController`: Routes commands to handlers
+- `StationService`: CRUD operations for radio stations with ID/name/default resolution
+- `CommandController`: Routes commands to handlers with error handling
 - `StationRepository`: Database access for stations table
+- `MessageView`: Consistent response formatting for all bot messages
+
+### Logging
+
+Uses pino for structured logging with child loggers per module:
+- `streamLogger`, `playerLogger`, `botLogger`, `configLogger`, `commandLogger`, `seedLogger`, `voiceLogger`
+- Pretty-printing in development, JSON in production
+- Configured via `LOG_LEVEL` environment variable
+
+### Error Handling & Recovery
+
+- `AudioService` implements retry logic with reconnection attempts (max 5, 5s delay)
+- Graceful shutdown on SIGINT with resource cleanup
+- Connection state listeners for Disconnected/Destroyed events
+- Stream errors trigger automatic reconnection
+- Auto-disconnect when all users leave the voice channel (via `VoiceStateUpdate` event)
+
+### Startup Behavior
+
+- Default station seeding on first run (if no stations exist)
+- Graceful shutdown handler registered for SIGINT
+- Suppresses TimeoutNegativeWarning from @discordjs/voice
+
+### Permissions
+
+Admin commands check both:
+1. Discord Administrator permission
+2. Configured `ADMIN_ROLE_ID` (if set)
+
+Falls back to Administrator check if no role ID configured.
 
 ### Commands
 
@@ -76,6 +113,23 @@ Use `@/*` to import from `src/*`:
 ```typescript
 import { something } from "@/utils";
 ```
+
+### Interfaces
+
+All services and repositories implement interfaces (in `interfaces/` subdirectories):
+- `IAudioService`, `IStreamService`, `IStationService`
+- `IStationRepository`
+- `ICommand` - Commands have `name`, `description`, `usage`, `adminOnly`, and `execute()`
+
+### Database Schema
+
+Stations table:
+- `id`: Serial primary key
+- `name`: Unique station name
+- `url`: Stream URL
+- `description`: Optional description
+- `isDefault`: Boolean for default station
+- `createdAt`, `updatedAt`: Timestamps (auto-managed)
 
 ## Release Process
 

--- a/src/commands/AddStationCommand.ts
+++ b/src/commands/AddStationCommand.ts
@@ -35,7 +35,10 @@ export class AddStationCommand implements ICommand {
       const station = await this.stationService.addStation(name, url, description);
       return { success: true, message: this.view.stationAdded(station) };
     } catch (error) {
-      commandLogger.error({ command: "addstation", name, url, err: error }, "Failed to add station");
+      commandLogger.error(
+        { command: "addstation", name, url, err: error },
+        "Failed to add station"
+      );
       return { success: false, message: "Failed to add station. Please try again." };
     }
   }

--- a/src/commands/PlayCommand.ts
+++ b/src/commands/PlayCommand.ts
@@ -47,7 +47,10 @@ export class PlayCommand implements ICommand {
 
       return { success: true, message: this.view.nowPlaying(station.name) };
     } catch (error) {
-      commandLogger.error({ command: "play", guildId, stationId: station.id, err: error }, "Failed to play station");
+      commandLogger.error(
+        { command: "play", guildId, stationId: station.id, err: error },
+        "Failed to play station"
+      );
       this.audioService.cleanup(guildId);
       return { success: false, message: this.view.failedToJoin() };
     }

--- a/src/commands/RemoveStationCommand.ts
+++ b/src/commands/RemoveStationCommand.ts
@@ -35,7 +35,10 @@ export class RemoveStationCommand implements ICommand {
       await this.stationService.removeStation(id);
       return { success: true, message: this.view.stationRemoved(id) };
     } catch (error) {
-      commandLogger.error({ command: "removestation", stationId: id, err: error }, "Failed to remove station");
+      commandLogger.error(
+        { command: "removestation", stationId: id, err: error },
+        "Failed to remove station"
+      );
       return { success: false, message: "Failed to remove station. Please try again." };
     }
   }

--- a/src/commands/SetDefaultCommand.ts
+++ b/src/commands/SetDefaultCommand.ts
@@ -35,7 +35,10 @@ export class SetDefaultCommand implements ICommand {
       await this.stationService.setDefaultStation(id);
       return { success: true, message: this.view.stationSetDefault(station) };
     } catch (error) {
-      commandLogger.error({ command: "setdefault", stationId: id, err: error }, "Failed to set default station");
+      commandLogger.error(
+        { command: "setdefault", stationId: id, err: error },
+        "Failed to set default station"
+      );
       return { success: false, message: "Failed to set default station. Please try again." };
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,10 @@ client.on(Events.MessageCreate, async (message) => {
   await commandController.handleMessage(message);
 });
 
+client.on(Events.VoiceStateUpdate, (oldState, newState) => {
+  audioService.handleVoiceStateUpdate(oldState, newState);
+});
+
 // Graceful shutdown
 process.on("SIGINT", () => {
   botLogger.info("Shutting down...");

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -9,6 +9,7 @@ export interface GuildAudioState {
   reconnectAttempts: number;
   isPlaying: boolean;
   currentStationId: number | null;
+  channelId: string;
 }
 
 export interface CommandContext {

--- a/src/services/AudioService.ts
+++ b/src/services/AudioService.ts
@@ -8,11 +8,11 @@ import {
   joinVoiceChannel,
   NoSubscriberBehavior,
 } from "@discordjs/voice";
-import type { VoiceBasedChannel } from "discord.js";
+import type { VoiceBasedChannel, VoiceState } from "discord.js";
 import { Readable } from "node:stream";
 import { config } from "@/config";
 import type { GuildAudioState } from "@/models/types";
-import { streamLogger, playerLogger, logger } from "@/utils/logger";
+import { streamLogger, playerLogger, logger, voiceLogger } from "@/utils/logger";
 import type { IAudioService } from "./interfaces/IAudioService";
 import type { IStreamService } from "./interfaces/IStreamService";
 
@@ -54,6 +54,7 @@ export class AudioService implements IAudioService {
       reconnectAttempts: 0,
       isPlaying: false,
       currentStationId: null,
+      channelId: channel.id,
     };
 
     this.guildStates.set(guildId, state);
@@ -84,7 +85,9 @@ export class AudioService implements IAudioService {
         throw new Error("Failed to create ffmpeg stdout stream");
       }
 
-      const nodeStream = Readable.fromWeb(state.ffmpegProcess.stdout as import("stream/web").ReadableStream);
+      const nodeStream = Readable.fromWeb(
+        state.ffmpegProcess.stdout as import("stream/web").ReadableStream
+      );
       const resource = createAudioResource(nodeStream, {
         inputType: StreamType.OggOpus,
       });
@@ -104,7 +107,10 @@ export class AudioService implements IAudioService {
 
   private async handleStreamError(state: GuildAudioState): Promise<void> {
     if (state.reconnectAttempts >= config.stream.maxReconnectAttempts) {
-      streamLogger.error({ maxAttempts: config.stream.maxReconnectAttempts }, "Max reconnection attempts reached");
+      streamLogger.error(
+        { maxAttempts: config.stream.maxReconnectAttempts },
+        "Max reconnection attempts reached"
+      );
       state.isPlaying = false;
       return;
     }
@@ -153,6 +159,30 @@ export class AudioService implements IAudioService {
   cleanupAll(): void {
     for (const guildId of this.guildStates.keys()) {
       this.cleanup(guildId);
+    }
+  }
+
+  handleVoiceStateUpdate(oldState: VoiceState, newState: VoiceState): void {
+    const guildId = oldState.guild.id;
+    const state = this.guildStates.get(guildId);
+
+    if (!state) return;
+
+    // Check if someone left the bot's channel
+    if (oldState.channelId === state.channelId && oldState.channelId !== newState.channelId) {
+      const channel = oldState.channel;
+      if (!channel) return;
+
+      // Count non-bot members in the channel
+      const humanMembers = channel.members.filter((member) => !member.user.bot).size;
+
+      if (humanMembers === 0) {
+        voiceLogger.info(
+          { guildId, channelId: state.channelId },
+          "All users left voice channel, stopping bot"
+        );
+        this.cleanup(guildId);
+      }
     }
   }
 

--- a/src/services/interfaces/IAudioService.ts
+++ b/src/services/interfaces/IAudioService.ts
@@ -1,4 +1,4 @@
-import type { VoiceBasedChannel } from "discord.js";
+import type { VoiceBasedChannel, VoiceState } from "discord.js";
 import type { GuildAudioState } from "@/models/types";
 
 export interface IAudioService {
@@ -9,4 +9,5 @@ export interface IAudioService {
   stopStream(guildId: string): void;
   cleanup(guildId: string): void;
   cleanupAll(): void;
+  handleVoiceStateUpdate(oldState: VoiceState, newState: VoiceState): void;
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -23,3 +23,4 @@ export const botLogger = logger.child({ module: "Bot" });
 export const configLogger = logger.child({ module: "Config" });
 export const commandLogger = logger.child({ module: "Command" });
 export const seedLogger = logger.child({ module: "Seed" });
+export const voiceLogger = logger.child({ module: "Voice" });


### PR DESCRIPTION
## Description

Automatically disconnect the bot from the voice channel when all users leave. This saves resources by not streaming audio to an empty channel.

### Changes:
- Added `VoiceStateUpdate` event listener in `src/index.ts`
- Added `channelId` field to `GuildAudioState` type to track the bot's channel
- Added `handleVoiceStateUpdate()` method to `AudioService` that detects when users leave and checks if the channel is empty
- Added `voiceLogger` for voice-related events
- Updated `CLAUDE.md` with `.github/` directory structure and documented the new auto-stop feature

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have tested my changes
- [x] I have updated documentation if needed

---

Closes #13

🤖 Generated with [Claude Code](https://claude.ai/code)