### PR TITLE
feat: add health check endpoint and command

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 DISCORD_TOKEN=your_discord_bot_token_here
 DATABASE_URL=postgresql://user:password@localhost:5432/lofi_bot
 ADMIN_ROLE_ID=your_admin_role_id_here
+LOG_LEVEL=info
+API_PORT=3000
+API_ENABLED=true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,8 @@ Copy `.env.example` to `.env` and configure:
 - `DATABASE_URL` - PostgreSQL connection string
 - `ADMIN_ROLE_ID` - (Optional) Role ID for admin commands
 - `LOG_LEVEL` - (Optional) Logging level: `debug`, `info`, `warn`, `error` (default: `info`)
+- `API_PORT` - (Optional) Port for HTTP API endpoint (default: `3000`)
+- `API_ENABLED` - (Optional) Enable/disable HTTP API (default: `true`)
 
 ## Architecture
 
@@ -63,6 +65,8 @@ src/
 - `AudioService`: Manages voice connections and audio playback with automatic reconnection
 - `StreamService`: Creates FFmpeg processes for audio streaming
 - `StationService`: CRUD operations for radio stations with ID/name/default resolution
+- `HealthService`: Provides health status (Discord, database, audio connections)
+- `HealthServer`: Elysia.js HTTP server for health check endpoint
 - `CommandController`: Routes commands to handlers with error handling
 - `StationRepository`: Database access for stations table
 - `MessageView`: Consistent response formatting for all bot messages
@@ -70,7 +74,7 @@ src/
 ### Logging
 
 Uses pino for structured logging with child loggers per module:
-- `streamLogger`, `playerLogger`, `botLogger`, `configLogger`, `commandLogger`, `seedLogger`, `voiceLogger`
+- `streamLogger`, `playerLogger`, `botLogger`, `configLogger`, `commandLogger`, `seedLogger`, `voiceLogger`, `healthLogger`
 - Pretty-printing in development, JSON in production
 - Configured via `LOG_LEVEL` environment variable
 
@@ -85,8 +89,28 @@ Uses pino for structured logging with child loggers per module:
 ### Startup Behavior
 
 - Default station seeding on first run (if no stations exist)
+- Health check HTTP server starts after Discord login (if enabled)
 - Graceful shutdown handler registered for SIGINT
 - Suppresses TimeoutNegativeWarning from @discordjs/voice
+
+### Health Check API
+
+HTTP endpoint powered by Elysia.js for external monitoring (Kubernetes, Docker, etc.):
+
+- `GET /` - API info
+- `GET /health` - Health status (200 OK or 503 Service Unavailable)
+
+Response format:
+```json
+{
+  "status": "healthy",
+  "timestamp": "2024-01-01T00:00:00.000Z",
+  "uptime": 3600,
+  "discord": { "connected": true, "ping": 45, "guilds": 5 },
+  "database": { "connected": true },
+  "audio": { "activeConnections": 2 }
+}
+```
 
 ### Permissions
 
@@ -103,6 +127,7 @@ Falls back to Administrator check if no role ID configured.
 | `!play [station]` | Play station (default if omitted) | Everyone |
 | `!stop` | Stop streaming and leave channel | Everyone |
 | `!stations` | List all available stations | Everyone |
+| `!health` | Check bot health status | Everyone |
 | `!addstation <name> <url> [desc]` | Add new station | Admin |
 | `!removestation <id>` | Remove a station | Admin |
 | `!setdefault <id>` | Set default station | Admin |
@@ -117,7 +142,7 @@ import { something } from "@/utils";
 ### Interfaces
 
 All services and repositories implement interfaces (in `interfaces/` subdirectories):
-- `IAudioService`, `IStreamService`, `IStationService`
+- `IAudioService`, `IStreamService`, `IStationService`, `IHealthService`
 - `IStationRepository`
 - `ICommand` - Commands have `name`, `description`, `usage`, `adminOnly`, and `execute()`
 

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@snazzah/davey": "^0.1.9",
         "discord.js": "^14.16.3",
         "drizzle-orm": "^0.45.1",
+        "elysia": "^1.4.22",
         "ffmpeg-static": "^5.2.0",
         "libsodium-wrappers": "^0.8.1",
         "pino": "^10.2.1",
@@ -28,6 +29,8 @@
     },
   },
   "packages": {
+    "@borewit/text-codec": ["@borewit/text-codec@0.2.1", "", {}, "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw=="],
+
     "@derhuerst/http-basic": ["@derhuerst/http-basic@8.2.4", "", { "dependencies": { "caseless": "^0.12.0", "concat-stream": "^2.0.0", "http-response-object": "^3.0.1", "parse-cache-control": "^1.0.1" } }, "sha512-F9rL9k9Xjf5blCz8HsJRO4diy111cayL2vkY2XE4r4t3n0yPXVYy3KD3nJ1qbrSn9743UWSXH4IwuCa/HWlGFw=="],
 
     "@discordjs/builders": ["@discordjs/builders@1.13.1", "", { "dependencies": { "@discordjs/formatters": "^0.6.2", "@discordjs/util": "^1.2.0", "@sapphire/shapeshift": "^4.0.0", "discord-api-types": "^0.38.33", "fast-deep-equal": "^3.1.3", "ts-mixer": "^6.0.4", "tslib": "^2.6.3" } }, "sha512-cOU0UDHc3lp/5nKByDxkmRiNZBpdp0kx55aarbiAfakfKJHlxv/yFW1zmIqCAmwH5CRlrH9iMFKJMpvW4DPB+w=="],
@@ -144,6 +147,8 @@
 
     "@sapphire/snowflake": ["@sapphire/snowflake@3.5.3", "", {}, "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ=="],
 
+    "@sinclair/typebox": ["@sinclair/typebox@0.34.48", "", {}, "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA=="],
+
     "@snazzah/davey": ["@snazzah/davey@0.1.9", "", { "optionalDependencies": { "@snazzah/davey-android-arm-eabi": "0.1.9", "@snazzah/davey-android-arm64": "0.1.9", "@snazzah/davey-darwin-arm64": "0.1.9", "@snazzah/davey-darwin-x64": "0.1.9", "@snazzah/davey-freebsd-x64": "0.1.9", "@snazzah/davey-linux-arm-gnueabihf": "0.1.9", "@snazzah/davey-linux-arm64-gnu": "0.1.9", "@snazzah/davey-linux-arm64-musl": "0.1.9", "@snazzah/davey-linux-x64-gnu": "0.1.9", "@snazzah/davey-linux-x64-musl": "0.1.9", "@snazzah/davey-wasm32-wasi": "0.1.9", "@snazzah/davey-win32-arm64-msvc": "0.1.9", "@snazzah/davey-win32-ia32-msvc": "0.1.9", "@snazzah/davey-win32-x64-msvc": "0.1.9" } }, "sha512-vNZk5y+IsxjwzTAXikvzz5pqMLb35YytC64nVF2MAFVhjpXu9ITOKUriZ0JG/llwzCAi56jb5x0cXDRIyE2A2A=="],
 
     "@snazzah/davey-android-arm-eabi": ["@snazzah/davey-android-arm-eabi@0.1.9", "", { "os": "android", "cpu": "arm" }, "sha512-Dq0WyeVGBw+uQbisV/6PeCQV2ndJozfhZqiNIfQxu6ehIdXB7iHILv+oY+AQN2n+qxiFmLh/MOX9RF+pIWdPbA=="],
@@ -173,6 +178,10 @@
     "@snazzah/davey-win32-ia32-msvc": ["@snazzah/davey-win32-ia32-msvc@0.1.9", "", { "os": "win32", "cpu": "ia32" }, "sha512-twD3LwlkGnSwphsCtpGb5ztpBIWEvGdc0iujoVkdzZ6nJiq5p8iaLjJMO4hBm9h3s28fc+1Qd7AMVnagiOasnA=="],
 
     "@snazzah/davey-win32-x64-msvc": ["@snazzah/davey-win32-x64-msvc@0.1.9", "", { "os": "win32", "cpu": "x64" }, "sha512-eMnXbv4GoTngWYY538i/qHz2BS+RgSXFsvKltPzKqnqzPzhQZIY7TemEJn3D5yWGfW4qHve9u23rz93FQqnQMA=="],
+
+    "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
+
+    "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
@@ -246,6 +255,8 @@
 
     "concat-stream": ["concat-stream@2.0.0", "", { "dependencies": { "buffer-from": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.0.2", "typedarray": "^0.0.6" } }, "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A=="],
 
+    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "dateformat": ["dateformat@4.6.3", "", {}, "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="],
@@ -261,6 +272,8 @@
     "drizzle-kit": ["drizzle-kit@0.31.8", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.25.4", "esbuild-register": "^3.5.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-O9EC/miwdnRDY10qRxM8P3Pg8hXe3LyU4ZipReKOgTwn4OqANmftj8XJz1UPUAS6NMHf0E2htjsbQujUTkncCg=="],
 
     "drizzle-orm": ["drizzle-orm@0.45.1", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-Te0FOdKIistGNPMq2jscdqngBRfBpC8uMFVwqjf6gtTVJHIQ/dosgV/CLBU2N4ZJBsXL5savCba9b0YJskKdcA=="],
+
+    "elysia": ["elysia@1.4.22", "", { "dependencies": { "cookie": "^1.1.1", "exact-mirror": "^0.2.6", "fast-decode-uri-component": "^1.0.1", "memoirist": "^0.4.0" }, "peerDependencies": { "@sinclair/typebox": ">= 0.34.0 < 1", "@types/bun": ">= 1.2.0", "file-type": ">= 20.0.0", "openapi-types": ">= 12.0.0", "typescript": ">= 5.0.0" }, "optionalPeers": ["@types/bun", "typescript"] }, "sha512-Q90VCb1RVFxnFaRV0FDoSylESQQLWgLHFmWciQJdX9h3b2cSasji9KWEUvaJuy/L9ciAGg4RAhUVfsXHg5K2RQ=="],
 
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
@@ -290,7 +303,11 @@
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
+    "exact-mirror": ["exact-mirror@0.2.6", "", { "peerDependencies": { "@sinclair/typebox": "^0.34.15" }, "optionalPeers": ["@sinclair/typebox"] }, "sha512-7s059UIx9/tnOKSySzUk5cPGkoILhTE4p6ncf6uIPaQ+9aRBQzQjc9+q85l51+oZ+P6aBxh084pD0CzBQPcFUA=="],
+
     "fast-copy": ["fast-copy@4.0.2", "", {}, "sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw=="],
+
+    "fast-decode-uri-component": ["fast-decode-uri-component@1.0.1", "", {}, "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -305,6 +322,8 @@
     "ffmpeg-static": ["ffmpeg-static@5.3.0", "", { "dependencies": { "@derhuerst/http-basic": "^8.2.0", "env-paths": "^2.2.0", "https-proxy-agent": "^5.0.0", "progress": "^2.0.3" } }, "sha512-H+K6sW6TiIX6VGend0KQwthe+kaceeH/luE8dIZyOP35ik7ahYojDuqlTV1bOrtEwl01sy2HFNGQfi5IDJvotg=="],
 
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
+
+    "file-type": ["file-type@21.3.0", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.4", "token-types": "^6.1.1", "uint8array-extras": "^1.4.0" } }, "sha512-8kPJMIGz1Yt/aPEwOsrR97ZyZaD1Iqm8PClb1nYFclUCkBi0Ma5IsYNQzvSFS9ib51lWyIw5mIT9rWzI/xjpzA=="],
 
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
@@ -325,6 +344,8 @@
     "http-response-object": ["http-response-object@3.0.2", "", { "dependencies": { "@types/node": "^10.0.3" } }, "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA=="],
 
     "https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
@@ -368,6 +389,8 @@
 
     "magic-bytes.js": ["magic-bytes.js@1.13.0", "", {}, "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg=="],
 
+    "memoirist": ["memoirist@0.4.0", "", {}, "sha512-zxTgA0mSYELa66DimuNQDvyLq36AwDlTuVRbnQtB+VuTcKWm5Qc4z3WkSpgsFWHNhexqkIooqpv4hdcqrX5Nmg=="],
+
     "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
@@ -379,6 +402,8 @@
     "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
@@ -454,11 +479,15 @@
 
     "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
 
+    "strtok3": ["strtok3@10.3.4", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg=="],
+
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "thread-stream": ["thread-stream@4.0.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA=="],
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
 
     "ts-api-utils": ["ts-api-utils@2.4.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA=="],
 
@@ -473,6 +502,8 @@
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "typescript-eslint": ["typescript-eslint@8.53.1", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.53.1", "@typescript-eslint/parser": "8.53.1", "@typescript-eslint/typescript-estree": "8.53.1", "@typescript-eslint/utils": "8.53.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-gB+EVQfP5RDElh9ittfXlhZJdjSU4jUSTyE2+ia8CYyNvet4ElfaLlAIqDvQV9JPknKx0jQH1racTYe/4LaLSg=="],
+
+    "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 
     "undici": ["undici@6.21.3", "", {}, "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw=="],
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@snazzah/davey": "^0.1.9",
     "discord.js": "^14.16.3",
     "drizzle-orm": "^0.45.1",
+    "elysia": "^1.4.22",
     "ffmpeg-static": "^5.2.0",
     "libsodium-wrappers": "^0.8.1",
     "pino": "^10.2.1",

--- a/src/commands/HealthCommand.ts
+++ b/src/commands/HealthCommand.ts
@@ -1,0 +1,20 @@
+import type { CommandContext, CommandResult } from "@/models/types";
+import type { IHealthService } from "@/services/interfaces/IHealthService";
+import { MessageView } from "@/views/MessageView";
+import type { ICommand } from "./interfaces/ICommand";
+
+export class HealthCommand implements ICommand {
+  readonly name = "health";
+  readonly description = "Check bot health status";
+  readonly usage = "!health";
+  readonly adminOnly = false;
+
+  private readonly view = new MessageView();
+
+  constructor(private readonly healthService: IHealthService) {}
+
+  async execute(_context: CommandContext): Promise<CommandResult> {
+    const status = await this.healthService.getStatus();
+    return { success: true, message: this.view.healthStatus(status) };
+  }
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -12,6 +12,10 @@ export const config = {
     reconnectDelayMs: 5000,
     maxReconnectAttempts: 5,
   },
+  api: {
+    port: parseInt(process.env.API_PORT || "3000", 10),
+    enabled: process.env.API_ENABLED !== "false",
+  },
 } as const;
 
 export function validateConfig(): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,10 @@ import { StationsCommand } from "@/commands/StationsCommand";
 import { AddStationCommand } from "@/commands/AddStationCommand";
 import { RemoveStationCommand } from "@/commands/RemoveStationCommand";
 import { SetDefaultCommand } from "@/commands/SetDefaultCommand";
+import { HealthCommand } from "@/commands/HealthCommand";
 import { CommandController } from "@/controllers/CommandController";
+import { HealthService } from "@/services/HealthService";
+import { HealthServer } from "@/services/HealthServer";
 import { botLogger, seedLogger } from "@/utils/logger";
 
 // Validate configuration
@@ -39,6 +42,8 @@ const stationRepository = new StationRepository(db);
 const stationService = new StationService(stationRepository);
 const streamService = new StreamService();
 const audioService = new AudioService(streamService);
+const healthService = new HealthService(client, db, audioService);
+const healthServer = config.api.enabled ? new HealthServer(healthService, config.api.port) : null;
 
 // Initialize controller and register commands
 const commandController = new CommandController();
@@ -49,6 +54,7 @@ commandController.registerCommands([
   new AddStationCommand(stationService),
   new RemoveStationCommand(stationService),
   new SetDefaultCommand(stationService),
+  new HealthCommand(healthService),
 ]);
 
 // Seed default station if none exist
@@ -70,6 +76,7 @@ async function seedDefaultStation(): Promise<void> {
 client.once(Events.ClientReady, async (readyClient) => {
   botLogger.info({ tag: readyClient.user.tag }, "Logged in");
   await seedDefaultStation();
+  healthServer?.start();
 });
 
 client.on(Events.MessageCreate, async (message) => {
@@ -83,6 +90,7 @@ client.on(Events.VoiceStateUpdate, (oldState, newState) => {
 // Graceful shutdown
 process.on("SIGINT", () => {
   botLogger.info("Shutting down...");
+  healthServer?.stop();
   audioService.cleanupAll();
   client.destroy();
   process.exit(0);

--- a/src/services/HealthServer.ts
+++ b/src/services/HealthServer.ts
@@ -1,0 +1,36 @@
+import { Elysia } from "elysia";
+import { healthLogger } from "@/utils/logger";
+import type { IHealthService } from "./interfaces/IHealthService";
+
+export class HealthServer {
+  private app: Elysia;
+
+  constructor(
+    private readonly healthService: IHealthService,
+    private readonly port: number
+  ) {
+    this.app = new Elysia()
+      .get("/", () => ({
+        name: "lofi-bot",
+        version: "1.0.0",
+        endpoints: ["/health"],
+      }))
+      .get("/health", async ({ set }) => {
+        const status = await this.healthService.getStatus();
+        if (status.status === "unhealthy") {
+          set.status = 503;
+        }
+        return status;
+      });
+  }
+
+  start(): void {
+    this.app.listen(this.port);
+    healthLogger.info({ port: this.port }, "Health server started");
+  }
+
+  stop(): void {
+    this.app.stop();
+    healthLogger.info("Health server stopped");
+  }
+}

--- a/src/services/HealthService.ts
+++ b/src/services/HealthService.ts
@@ -1,0 +1,69 @@
+import type { Client } from "discord.js";
+import { sql } from "drizzle-orm";
+import type { BunSQLiteDatabase } from "drizzle-orm/bun-sqlite";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import type { IAudioService } from "./interfaces/IAudioService";
+import type { HealthStatus, IHealthService } from "./interfaces/IHealthService";
+
+type Database = BunSQLiteDatabase | PostgresJsDatabase;
+
+export class HealthService implements IHealthService {
+  private readonly startTime: number;
+
+  constructor(
+    private readonly client: Client,
+    private readonly db: Database,
+    private readonly audioService: IAudioService
+  ) {
+    this.startTime = Date.now();
+  }
+
+  async getStatus(): Promise<HealthStatus> {
+    const [dbConnected, audioConnections] = await Promise.all([
+      this.checkDatabase(),
+      this.getAudioConnections(),
+    ]);
+
+    const discordConnected = this.client.isReady();
+    const isHealthy = discordConnected && dbConnected;
+
+    return {
+      status: isHealthy ? "healthy" : "unhealthy",
+      timestamp: new Date().toISOString(),
+      uptime: Math.floor((Date.now() - this.startTime) / 1000),
+      discord: {
+        connected: discordConnected,
+        ping: this.client.ws.ping,
+        guilds: this.client.guilds.cache.size,
+      },
+      database: {
+        connected: dbConnected,
+      },
+      audio: {
+        activeConnections: audioConnections,
+      },
+    };
+  }
+
+  private async checkDatabase(): Promise<boolean> {
+    try {
+      await (this.db as PostgresJsDatabase).execute(sql`SELECT 1`);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private getAudioConnections(): number {
+    // Count active guild states from AudioService
+    let count = 0;
+    // We need to access the internal state - for now we'll use a simple approach
+    // by checking if hasState returns true for known guilds
+    for (const guild of this.client.guilds.cache.values()) {
+      if (this.audioService.hasState(guild.id)) {
+        count++;
+      }
+    }
+    return count;
+  }
+}

--- a/src/services/interfaces/IHealthService.ts
+++ b/src/services/interfaces/IHealthService.ts
@@ -1,0 +1,20 @@
+export interface HealthStatus {
+  status: "healthy" | "unhealthy";
+  timestamp: string;
+  uptime: number;
+  discord: {
+    connected: boolean;
+    ping: number;
+    guilds: number;
+  };
+  database: {
+    connected: boolean;
+  };
+  audio: {
+    activeConnections: number;
+  };
+}
+
+export interface IHealthService {
+  getStatus(): Promise<HealthStatus>;
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -24,3 +24,4 @@ export const configLogger = logger.child({ module: "Config" });
 export const commandLogger = logger.child({ module: "Command" });
 export const seedLogger = logger.child({ module: "Seed" });
 export const voiceLogger = logger.child({ module: "Voice" });
+export const healthLogger = logger.child({ module: "Health" });

--- a/src/views/MessageView.ts
+++ b/src/views/MessageView.ts
@@ -1,4 +1,5 @@
 import type { Station } from "@/database/schema";
+import type { HealthStatus } from "@/services/interfaces/IHealthService";
 
 export class MessageView {
   notInVoiceChannel(): string {
@@ -74,5 +75,34 @@ export class MessageView {
 
   permissionDenied(): string {
     return "You don't have permission to use this command.";
+  }
+
+  healthStatus(status: HealthStatus): string {
+    const emoji = status.status === "healthy" ? "✅" : "❌";
+    const lines = [
+      `${emoji} **Bot Status: ${status.status.toUpperCase()}**`,
+      "",
+      `⏱️ Uptime: ${this.formatUptime(status.uptime)}`,
+      `📡 Discord: ${status.discord.connected ? "Connected" : "Disconnected"} (${status.discord.ping}ms)`,
+      `🏠 Guilds: ${status.discord.guilds}`,
+      `🔊 Active Streams: ${status.audio.activeConnections}`,
+      `🗄️ Database: ${status.database.connected ? "Connected" : "Disconnected"}`,
+    ];
+    return lines.join("\n");
+  }
+
+  private formatUptime(seconds: number): string {
+    const days = Math.floor(seconds / 86400);
+    const hours = Math.floor((seconds % 86400) / 3600);
+    const minutes = Math.floor((seconds % 3600) / 60);
+    const secs = seconds % 60;
+
+    const parts: string[] = [];
+    if (days > 0) parts.push(`${days}d`);
+    if (hours > 0) parts.push(`${hours}h`);
+    if (minutes > 0) parts.push(`${minutes}m`);
+    parts.push(`${secs}s`);
+
+    return parts.join(" ");
   }
 }


### PR DESCRIPTION
## Description

Add health check functionality for external monitoring and Discord users:

### HTTP API (Elysia.js)
- `GET /` - API info
- `GET /health` - Health status (200 OK or 503 Service Unavailable)

### Discord Command
- `!health` - Shows formatted bot status in Discord

### Health Checks
- Discord connection status and ping
- Database connectivity
- Active audio connections count
- Uptime tracking

### Configuration
- `API_PORT` - Port for HTTP API (default: 3000)
- `API_ENABLED` - Enable/disable HTTP API (default: true)

Uses generic API naming to support future REST API expansion.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have tested my changes
- [x] I have updated documentation if needed

---

Closes #11

🤖 Generated with [Claude Code](https://claude.ai/code)