### PR TITLE
feat: protect API endpoints with X-API-Key authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,4 @@ ADMIN_ROLE_ID=your_admin_role_id_here
 LOG_LEVEL=info
 API_PORT=3000
 API_ENABLED=true
+API_KEY=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ Copy `.env.example` to `.env` and configure:
 - `LOG_LEVEL` - (Optional) Logging level: `debug`, `info`, `warn`, `error` (default: `info`)
 - `API_PORT` - (Optional) Port for HTTP API endpoint (default: `3000`)
 - `API_ENABLED` - (Optional) Enable/disable HTTP API (default: `true`)
+- `API_KEY` - (Optional) API key for authenticating HTTP API requests. If set, all API endpoints require `X-API-Key` header
 
 ## Architecture
 
@@ -99,6 +100,19 @@ HTTP endpoint powered by Elysia.js for external monitoring (Kubernetes, Docker, 
 
 - `GET /` - API info
 - `GET /health` - Health status (200 OK or 503 Service Unavailable)
+
+#### Authentication
+
+If `API_KEY` is configured, all endpoints require the `X-API-Key` header:
+```bash
+curl -H "X-API-Key: your-api-key" http://localhost:3000/health
+```
+
+Responses:
+- `401 Unauthorized` - Missing `X-API-Key` header
+- `403 Forbidden` - Invalid API key
+
+If `API_KEY` is not set, endpoints are publicly accessible (no authentication required).
 
 Response format:
 ```json

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -15,6 +15,7 @@ export const config = {
   api: {
     port: parseInt(process.env.API_PORT || "3000", 10),
     enabled: process.env.API_ENABLED !== "false",
+    key: process.env.API_KEY || "",
   },
 } as const;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,9 @@ const stationService = new StationService(stationRepository);
 const streamService = new StreamService();
 const audioService = new AudioService(streamService);
 const healthService = new HealthService(client, db, audioService);
-const healthServer = config.api.enabled ? new HealthServer(healthService, config.api.port) : null;
+const healthServer = config.api.enabled
+  ? new HealthServer(healthService, config.api.port, config.api.key || undefined)
+  : null;
 
 // Initialize controller and register commands
 const commandController = new CommandController();

--- a/src/services/HealthServer.ts
+++ b/src/services/HealthServer.ts
@@ -7,9 +7,24 @@ export class HealthServer {
 
   constructor(
     private readonly healthService: IHealthService,
-    private readonly port: number
+    private readonly port: number,
+    private readonly apiKey?: string
   ) {
-    this.app = new Elysia()
+    this.app = new Elysia();
+
+    if (this.apiKey) {
+      this.app.guard({
+        beforeHandle: ({ headers, set }) => {
+          const providedKey = headers["x-api-key"];
+          if (providedKey !== this.apiKey) {
+            set.status = 401;
+            return { error: "Invalid or missing API key" };
+          }
+        },
+      });
+    }
+
+    this.app
       .get("/", () => ({
         name: "lofi-bot",
         version: "1.0.0",


### PR DESCRIPTION
## Summary

- Add `API_KEY` environment variable for configuring the secret key
- Add Elysia.js guard middleware that validates `X-API-Key` header on all requests
- Return `401 Unauthorized` with error message if key is missing or invalid
- If `API_KEY` is not configured, endpoints remain publicly accessible (backwards compatible)

## Changes

- `.env.example` - Added `API_KEY` variable
- `src/config/index.ts` - Added `api.key` configuration
- `src/services/HealthServer.ts` - Added guard middleware for API key validation
- `src/index.ts` - Pass API key to HealthServer constructor
- `CLAUDE.md` - Updated documentation

## Example Usage

```bash
# With API_KEY configured
curl -H "X-API-Key: your-secret-key" http://localhost:3000/health

# Without valid key → 401 Unauthorized
curl http://localhost:3000/health
# {"error": "Invalid or missing API key"}
```

## Test plan

- [x] Set `API_KEY` env var and verify requests without header return 401
- [x] Verify requests with correct `X-API-Key` header succeed
- [x] Verify requests with incorrect key return 401
- [x] Remove `API_KEY` env var and verify endpoints are publicly accessible

Closes #21

🤖 Generated with [Claude Code](https://claude.ai/code)