### PR TITLE
feat: enable CORS and expose API config in docker-compose

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "lofi-bot",
       "dependencies": {
         "@discordjs/voice": "^0.19.0",
+        "@elysiajs/cors": "^1.4.1",
         "@snazzah/davey": "^0.1.9",
         "discord.js": "^14.16.3",
         "drizzle-orm": "^0.45.1",
@@ -48,6 +49,8 @@
     "@discordjs/ws": ["@discordjs/ws@1.2.3", "", { "dependencies": { "@discordjs/collection": "^2.1.0", "@discordjs/rest": "^2.5.1", "@discordjs/util": "^1.1.0", "@sapphire/async-queue": "^1.5.2", "@types/ws": "^8.5.10", "@vladfrangu/async_event_emitter": "^2.2.4", "discord-api-types": "^0.38.1", "tslib": "^2.6.2", "ws": "^8.17.0" } }, "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw=="],
 
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
+
+    "@elysiajs/cors": ["@elysiajs/cors@1.4.1", "", { "peerDependencies": { "elysia": ">= 1.4.0" } }, "sha512-lQfad+F3r4mNwsxRKbXyJB8Jg43oAOXjRwn7sKUL6bcOW3KjUqUimTS+woNpO97efpzjtDE0tEjGk9DTw8lqTQ=="],
 
     "@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,11 @@ services:
       - DISCORD_TOKEN=${DISCORD_TOKEN}
       - DATABASE_URL=postgresql://lofi:lofi@db:5432/lofi_bot
       - ADMIN_ROLE_ID=${ADMIN_ROLE_ID:-}
+      - API_PORT=${API_PORT:-3000}
+      - API_ENABLED=${API_ENABLED:-true}
+      - API_KEY=${API_KEY:-}
+    ports:
+      - "${API_PORT:-3000}:${API_PORT:-3000}"
     restart: unless-stopped
 
   db:

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@discordjs/voice": "^0.19.0",
+    "@elysiajs/cors": "^1.4.1",
     "@snazzah/davey": "^0.1.9",
     "discord.js": "^14.16.3",
     "drizzle-orm": "^0.45.1",

--- a/src/services/HealthServer.ts
+++ b/src/services/HealthServer.ts
@@ -1,4 +1,5 @@
 import { Elysia } from "elysia";
+import { cors } from "@elysiajs/cors";
 import { healthLogger } from "@/utils/logger";
 import type { IHealthService } from "./interfaces/IHealthService";
 
@@ -10,7 +11,7 @@ export class HealthServer {
     private readonly port: number,
     private readonly apiKey?: string
   ) {
-    this.app = new Elysia();
+    this.app = new Elysia().use(cors());
 
     if (this.apiKey) {
       this.app.guard({


### PR DESCRIPTION
## Summary
- Add `@elysiajs/cors` plugin to `HealthServer` so the dashboard can make cross-origin API requests
- Pass `API_PORT`, `API_ENABLED`, and `API_KEY` environment variables through `docker-compose.yml`
- Expose the API port in docker-compose for external access

## Test plan
- [x] Run `bun run dev` and verify the health server starts with CORS headers (`Access-Control-Allow-Origin`)
- [x] Run `docker compose up -d` and verify the API port is accessible from outside the container
- [x] Confirm the dashboard can reach `GET /health` without CORS errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)