### PR TITLE
feat: session-based listening time tracking

### DIFF
--- a/drizzle/0000_modern_black_panther.sql
+++ b/drizzle/0000_modern_black_panther.sql
@@ -1,0 +1,56 @@
+CREATE TABLE "guild_user_stats" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"guild_id" varchar(255) NOT NULL,
+	"user_id" varchar(255) NOT NULL,
+	"nickname" varchar(100),
+	"minutes_listened" integer DEFAULT 0 NOT NULL,
+	"xp" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "guilds" (
+	"guild_id" varchar(255) PRIMARY KEY NOT NULL,
+	"name" varchar(100) NOT NULL,
+	"icon_url" text,
+	"member_count" integer,
+	"owner_id" varchar(255),
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "listening_sessions" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"guild_id" varchar(255) NOT NULL,
+	"user_id" varchar(255) NOT NULL,
+	"station_id" integer NOT NULL,
+	"started_at" timestamp DEFAULT now() NOT NULL,
+	"finished_at" timestamp,
+	"duration_minutes" integer,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "stations" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" varchar(100) NOT NULL,
+	"url" text NOT NULL,
+	"description" text,
+	"is_default" boolean DEFAULT false,
+	"created_at" timestamp DEFAULT now(),
+	"updated_at" timestamp DEFAULT now(),
+	CONSTRAINT "stations_name_unique" UNIQUE("name")
+);
+--> statement-breakpoint
+CREATE TABLE "user_profiles" (
+	"user_id" varchar(255) PRIMARY KEY NOT NULL,
+	"username" varchar(100),
+	"display_name" varchar(100),
+	"avatar_url" text,
+	"total_minutes_listened" integer DEFAULT 0 NOT NULL,
+	"current_level" integer DEFAULT 1 NOT NULL,
+	"total_xp" integer DEFAULT 0 NOT NULL,
+	"last_active" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,355 @@
+{
+  "id": "e455126f-684c-4263-bd04-63d3b2a9de3b",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.guild_user_stats": {
+      "name": "guild_user_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minutes_listened": {
+          "name": "minutes_listened",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "xp": {
+          "name": "xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guilds": {
+      "name": "guilds",
+      "schema": "",
+      "columns": {
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_count": {
+          "name": "member_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.listening_sessions": {
+      "name": "listening_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stations": {
+      "name": "stations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stations_name_unique": {
+          "name": "stations_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_minutes_listened": {
+          "name": "total_minutes_listened",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_level": {
+          "name": "current_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "total_xp": {
+          "name": "total_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_active": {
+          "name": "last_active",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1770557518849,
+      "tag": "0000_modern_black_panther",
+      "breakpoints": true
+    }
+  ]
+}

--- a/src/commands/PlayCommand.ts
+++ b/src/commands/PlayCommand.ts
@@ -1,6 +1,7 @@
 import type { VoiceBasedChannel } from "discord.js";
 import type { CommandContext, CommandResult } from "@/models/types";
 import type { IAudioService } from "@/services/interfaces/IAudioService";
+import type { ISessionService } from "@/services/interfaces/ISessionService";
 import type { IStationService } from "@/services/interfaces/IStationService";
 import { commandLogger } from "@/utils/logger";
 import { MessageView } from "@/views/MessageView";
@@ -16,7 +17,8 @@ export class PlayCommand implements ICommand {
 
   constructor(
     private readonly audioService: IAudioService,
-    private readonly stationService: IStationService
+    private readonly stationService: IStationService,
+    private readonly sessionService: ISessionService
   ) {}
 
   async execute(context: CommandContext): Promise<CommandResult> {
@@ -44,6 +46,15 @@ export class PlayCommand implements ICommand {
     try {
       await this.audioService.joinChannel(voiceChannel);
       await this.audioService.startStream(guildId, station.url);
+
+      // Start listening session for the user
+      const userId = message.author.id;
+      await this.sessionService.startSession(guildId, userId, station.id, {
+        userId,
+        username: message.author.username,
+        displayName: message.author.displayName,
+        avatarUrl: message.author.avatarURL(),
+      });
 
       return { success: true, message: this.view.nowPlaying(station.name) };
     } catch (error) {

--- a/src/controllers/CommandController.ts
+++ b/src/controllers/CommandController.ts
@@ -1,21 +1,13 @@
 import type { Message } from "discord.js";
 import type { ICommand } from "@/commands/interfaces/ICommand";
-import type {
-  DiscordGuildData,
-  DiscordMemberData,
-  DiscordUserData,
-  IProfileService,
-} from "@/services/interfaces/IProfileService";
 import { isAdmin } from "@/utils/permissions";
-import { commandLogger, profileLogger } from "@/utils/logger";
+import { commandLogger } from "@/utils/logger";
 import { MessageView } from "@/views/MessageView";
 
 export class CommandController {
   private readonly commands = new Map<string, ICommand>();
   private readonly view = new MessageView();
   private readonly prefix = "!";
-
-  constructor(private readonly profileService?: IProfileService) {}
 
   registerCommand(command: ICommand): void {
     this.commands.set(command.name.toLowerCase(), command);
@@ -50,76 +42,9 @@ export class CommandController {
     try {
       const result = await command.execute({ message, args });
       await message.reply(result.message);
-
-      // Add XP for successful command execution
-      if (this.profileService && result.success) {
-        await this.addXpForInteraction(message);
-      }
     } catch (error) {
       commandLogger.error({ command: commandName, err: error }, "Error executing command");
       await message.reply("An unexpected error occurred. Please try again.");
-    }
-  }
-
-  private async addXpForInteraction(message: Message): Promise<void> {
-    if (!this.profileService || !message.guild) return;
-
-    const userId = message.author.id;
-    const guildId = message.guild.id;
-
-    // Extract Discord user info
-    const discordUser: DiscordUserData = {
-      userId: message.author.id,
-      username: message.author.username,
-      displayName: message.author.displayName,
-      avatarUrl: message.author.avatarURL(),
-    };
-
-    // Extract Discord guild info
-    const discordGuild: DiscordGuildData = {
-      guildId: message.guild.id,
-      name: message.guild.name,
-      iconUrl: message.guild.iconURL(),
-      memberCount: message.guild.memberCount,
-      ownerId: message.guild.ownerId,
-    };
-
-    // Extract Discord member info
-    const discordMember: DiscordMemberData = {
-      nickname: message.member?.nickname ?? null,
-    };
-
-    try {
-      const { profile, leveledUp, newLevel } = await this.profileService.addXpAndMinutes(
-        userId,
-        guildId,
-        1, // 1 minute of XP per interaction
-        discordUser,
-        discordGuild,
-        discordMember
-      );
-
-      profileLogger.debug(
-        { userId, guildId, totalXp: profile.totalXp, level: profile.currentLevel },
-        "Added XP for interaction"
-      );
-
-      if (leveledUp) {
-        profileLogger.info({ userId, newLevel }, "User leveled up!");
-        await this.sendLevelUpNotification(message, newLevel);
-      }
-    } catch (error) {
-      profileLogger.error({ userId, guildId, err: error }, "Failed to add XP");
-    }
-  }
-
-  private async sendLevelUpNotification(message: Message, newLevel: number): Promise<void> {
-    const notification = this.view.levelUpNotification(message.author.toString(), newLevel);
-
-    try {
-      await message.channel.send(notification);
-    } catch (error) {
-      profileLogger.error({ err: error }, "Failed to send level up notification");
     }
   }
 }

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -55,3 +55,18 @@ export const guildUserStats = pgTable("guild_user_stats", {
 
 export type GuildUserStats = typeof guildUserStats.$inferSelect;
 export type NewGuildUserStats = typeof guildUserStats.$inferInsert;
+
+export const listeningSessions = pgTable("listening_sessions", {
+  id: serial("id").primaryKey(),
+  guildId: varchar("guild_id", { length: 255 }).notNull(),
+  userId: varchar("user_id", { length: 255 }).notNull(),
+  stationId: integer("station_id").notNull(),
+  startedAt: timestamp("started_at").defaultNow().notNull(),
+  finishedAt: timestamp("finished_at"),
+  durationMinutes: integer("duration_minutes"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
+
+export type ListeningSession = typeof listeningSessions.$inferSelect;
+export type NewListeningSession = typeof listeningSessions.$inferInsert;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,10 +12,12 @@ import { StationRepository } from "@/repositories/StationRepository";
 import { UserProfileRepository } from "@/repositories/UserProfileRepository";
 import { GuildUserStatsRepository } from "@/repositories/GuildUserStatsRepository";
 import { GuildRepository } from "@/repositories/GuildRepository";
+import { SessionRepository } from "@/repositories/SessionRepository";
 import { AudioService } from "@/services/AudioService";
 import { StationService } from "@/services/StationService";
 import { StreamService } from "@/services/StreamService";
 import { ProfileService } from "@/services/ProfileService";
+import { SessionService } from "@/services/SessionService";
 import { PlayCommand } from "@/commands/PlayCommand";
 import { StopCommand } from "@/commands/StopCommand";
 import { StationsCommand } from "@/commands/StationsCommand";
@@ -50,6 +52,7 @@ const stationRepository = new StationRepository(db);
 const userProfileRepository = new UserProfileRepository(db);
 const guildUserStatsRepository = new GuildUserStatsRepository(db);
 const guildRepository = new GuildRepository(db);
+const sessionRepository = new SessionRepository(db);
 const stationService = new StationService(stationRepository);
 const streamService = new StreamService();
 const audioService = new AudioService(streamService);
@@ -58,6 +61,8 @@ const profileService = new ProfileService(
   guildUserStatsRepository,
   guildRepository
 );
+const sessionService = new SessionService(sessionRepository, profileService);
+audioService.setSessionService(sessionService);
 const healthService = new HealthService(client, db, audioService);
 const stationController = new StationController(stationService);
 const apiServer = config.api.enabled
@@ -65,9 +70,9 @@ const apiServer = config.api.enabled
   : null;
 
 // Initialize controller and register commands
-const commandController = new CommandController(profileService);
+const commandController = new CommandController();
 commandController.registerCommands([
-  new PlayCommand(audioService, stationService),
+  new PlayCommand(audioService, stationService, sessionService),
   new StopCommand(audioService),
   new StationsCommand(stationService),
   new AddStationCommand(stationService),
@@ -98,6 +103,7 @@ async function seedDefaultStation(): Promise<void> {
 client.once(Events.ClientReady, async (readyClient) => {
   botLogger.info({ tag: readyClient.user.tag }, "Logged in");
   await seedDefaultStation();
+  await sessionService.cleanupOrphanedSessions();
   apiServer?.start();
 });
 
@@ -110,7 +116,7 @@ client.on(Events.VoiceStateUpdate, (oldState, newState) => {
 });
 
 // Graceful shutdown
-process.on("SIGINT", () => {
+process.on("SIGINT", async () => {
   botLogger.info("Shutting down...");
   apiServer?.stop();
   audioService.cleanupAll();

--- a/src/repositories/SessionRepository.ts
+++ b/src/repositories/SessionRepository.ts
@@ -1,0 +1,65 @@
+import { and, eq, isNull } from "drizzle-orm";
+import type { Database } from "@/database/connection";
+import {
+  listeningSessions,
+  type ListeningSession,
+  type NewListeningSession,
+} from "@/database/schema";
+import type { ISessionRepository } from "./interfaces/ISessionRepository";
+
+export class SessionRepository implements ISessionRepository {
+  constructor(private readonly db: Database) {}
+
+  async create(session: NewListeningSession): Promise<ListeningSession> {
+    const result = await this.db.insert(listeningSessions).values(session).returning();
+    return result[0]!;
+  }
+
+  async findActiveByGuildAndUser(
+    guildId: string,
+    userId: string
+  ): Promise<ListeningSession | undefined> {
+    const result = await this.db
+      .select()
+      .from(listeningSessions)
+      .where(
+        and(
+          eq(listeningSessions.guildId, guildId),
+          eq(listeningSessions.userId, userId),
+          isNull(listeningSessions.finishedAt)
+        )
+      )
+      .limit(1);
+    return result[0];
+  }
+
+  async findActiveByGuild(guildId: string): Promise<ListeningSession[]> {
+    return await this.db
+      .select()
+      .from(listeningSessions)
+      .where(and(eq(listeningSessions.guildId, guildId), isNull(listeningSessions.finishedAt)));
+  }
+
+  async endSession(
+    id: number,
+    finishedAt: Date,
+    durationMinutes: number
+  ): Promise<ListeningSession | undefined> {
+    const result = await this.db
+      .update(listeningSessions)
+      .set({ finishedAt, durationMinutes, updatedAt: new Date() })
+      .where(eq(listeningSessions.id, id))
+      .returning();
+    return result[0];
+  }
+
+  async endOrphanedSessions(): Promise<number> {
+    const now = new Date();
+    const result = await this.db
+      .update(listeningSessions)
+      .set({ finishedAt: now, durationMinutes: 0, updatedAt: now })
+      .where(isNull(listeningSessions.finishedAt))
+      .returning();
+    return result.length;
+  }
+}

--- a/src/repositories/interfaces/ISessionRepository.ts
+++ b/src/repositories/interfaces/ISessionRepository.ts
@@ -1,0 +1,13 @@
+import type { ListeningSession, NewListeningSession } from "@/database/schema";
+
+export interface ISessionRepository {
+  create(session: NewListeningSession): Promise<ListeningSession>;
+  findActiveByGuildAndUser(guildId: string, userId: string): Promise<ListeningSession | undefined>;
+  findActiveByGuild(guildId: string): Promise<ListeningSession[]>;
+  endSession(
+    id: number,
+    finishedAt: Date,
+    durationMinutes: number
+  ): Promise<ListeningSession | undefined>;
+  endOrphanedSessions(): Promise<number>;
+}

--- a/src/services/AudioService.ts
+++ b/src/services/AudioService.ts
@@ -14,12 +14,18 @@ import { config } from "@/config";
 import type { GuildAudioState } from "@/models/types";
 import { streamLogger, playerLogger, logger, voiceLogger } from "@/utils/logger";
 import type { IAudioService } from "./interfaces/IAudioService";
+import type { ISessionService } from "./interfaces/ISessionService";
 import type { IStreamService } from "./interfaces/IStreamService";
 
 export class AudioService implements IAudioService {
   private readonly guildStates = new Map<string, GuildAudioState>();
+  private sessionService?: ISessionService;
 
   constructor(private readonly streamService: IStreamService) {}
+
+  setSessionService(sessionService: ISessionService): void {
+    this.sessionService = sessionService;
+  }
 
   getState(guildId: string): GuildAudioState | undefined {
     return this.guildStates.get(guildId);
@@ -147,6 +153,11 @@ export class AudioService implements IAudioService {
       // Delete first to prevent re-entrant calls from the Destroyed event
       this.guildStates.delete(guildId);
 
+      // End all listening sessions for this guild
+      this.sessionService?.endAllGuildSessions(guildId).catch((error) => {
+        voiceLogger.error({ guildId, err: error }, "Failed to end guild sessions during cleanup");
+      });
+
       state.isPlaying = false;
       if (state.ffmpegProcess) {
         state.ffmpegProcess.kill();
@@ -170,6 +181,15 @@ export class AudioService implements IAudioService {
 
     // Check if someone left the bot's channel
     if (oldState.channelId === state.channelId && oldState.channelId !== newState.channelId) {
+      const userId = oldState.member?.id;
+
+      // End the leaving user's session
+      if (userId && !oldState.member?.user.bot) {
+        this.sessionService?.endSession(guildId, userId).catch((error) => {
+          voiceLogger.error({ guildId, userId, err: error }, "Failed to end user session on leave");
+        });
+      }
+
       const channel = oldState.channel;
       if (!channel) return;
 

--- a/src/services/SessionService.ts
+++ b/src/services/SessionService.ts
@@ -1,0 +1,84 @@
+import type { ISessionRepository } from "@/repositories/interfaces/ISessionRepository";
+import type { DiscordUserData, IProfileService } from "@/services/interfaces/IProfileService";
+import type { ISessionService } from "./interfaces/ISessionService";
+import { sessionLogger } from "@/utils/logger";
+
+export class SessionService implements ISessionService {
+  constructor(
+    private readonly sessionRepository: ISessionRepository,
+    private readonly profileService: IProfileService
+  ) {}
+
+  async startSession(
+    guildId: string,
+    userId: string,
+    stationId: number,
+    discordUser?: DiscordUserData
+  ): Promise<void> {
+    // Ensure user profile exists
+    await this.profileService.getOrCreateProfile(userId, discordUser);
+
+    // End any existing active session for this user in this guild
+    const existing = await this.sessionRepository.findActiveByGuildAndUser(guildId, userId);
+    if (existing) {
+      sessionLogger.warn(
+        { guildId, userId, sessionId: existing.id },
+        "Found existing active session, ending it before starting new one"
+      );
+      await this.endSession(guildId, userId);
+    }
+
+    await this.sessionRepository.create({ guildId, userId, stationId });
+    sessionLogger.info({ guildId, userId, stationId }, "Started listening session");
+  }
+
+  async endSession(guildId: string, userId: string): Promise<number> {
+    const session = await this.sessionRepository.findActiveByGuildAndUser(guildId, userId);
+    if (!session) {
+      sessionLogger.debug({ guildId, userId }, "No active session found to end");
+      return 0;
+    }
+
+    const now = new Date();
+    const durationMinutes = Math.floor((now.getTime() - session.startedAt.getTime()) / 60000);
+
+    await this.sessionRepository.endSession(session.id, now, durationMinutes);
+
+    if (durationMinutes > 0) {
+      try {
+        await this.profileService.addXpAndMinutes(userId, guildId, durationMinutes);
+      } catch (error) {
+        sessionLogger.error(
+          { userId, guildId, durationMinutes, err: error },
+          "Failed to add XP for session"
+        );
+      }
+    }
+
+    sessionLogger.info(
+      { guildId, userId, durationMinutes, sessionId: session.id },
+      "Ended listening session"
+    );
+    return durationMinutes;
+  }
+
+  async endAllGuildSessions(guildId: string): Promise<void> {
+    const activeSessions = await this.sessionRepository.findActiveByGuild(guildId);
+    for (const session of activeSessions) {
+      await this.endSession(guildId, session.userId);
+    }
+    if (activeSessions.length > 0) {
+      sessionLogger.info(
+        { guildId, count: activeSessions.length },
+        "Ended all guild listening sessions"
+      );
+    }
+  }
+
+  async cleanupOrphanedSessions(): Promise<void> {
+    const count = await this.sessionRepository.endOrphanedSessions();
+    if (count > 0) {
+      sessionLogger.info({ count }, "Cleaned up orphaned listening sessions");
+    }
+  }
+}

--- a/src/services/interfaces/IAudioService.ts
+++ b/src/services/interfaces/IAudioService.ts
@@ -1,5 +1,6 @@
 import type { VoiceBasedChannel, VoiceState } from "discord.js";
 import type { GuildAudioState } from "@/models/types";
+import type { ISessionService } from "./ISessionService";
 
 export interface IAudioService {
   getState(guildId: string): GuildAudioState | undefined;
@@ -10,4 +11,5 @@ export interface IAudioService {
   cleanup(guildId: string): void;
   cleanupAll(): void;
   handleVoiceStateUpdate(oldState: VoiceState, newState: VoiceState): void;
+  setSessionService(sessionService: ISessionService): void;
 }

--- a/src/services/interfaces/ISessionService.ts
+++ b/src/services/interfaces/ISessionService.ts
@@ -1,0 +1,13 @@
+import type { DiscordUserData } from "@/services/interfaces/IProfileService";
+
+export interface ISessionService {
+  startSession(
+    guildId: string,
+    userId: string,
+    stationId: number,
+    discordUser?: DiscordUserData
+  ): Promise<void>;
+  endSession(guildId: string, userId: string): Promise<number>;
+  endAllGuildSessions(guildId: string): Promise<void>;
+  cleanupOrphanedSessions(): Promise<void>;
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -26,3 +26,4 @@ export const seedLogger = logger.child({ module: "Seed" });
 export const voiceLogger = logger.child({ module: "Voice" });
 export const healthLogger = logger.child({ module: "Health" });
 export const profileLogger = logger.child({ module: "Profile" });
+export const sessionLogger = logger.child({ module: "Session" });


### PR DESCRIPTION
## Summary

- Adds `listening_sessions` table to track real listening duration per user
- `PlayCommand` creates a session on `!play`, sessions end on `!stop`, voice leave, bot disconnect, or shutdown
- Replaces hardcoded 1-min-per-command XP with actual minutes listened
- Orphaned sessions from previous bot runs are cleaned up on startup

Closes #38
Closes #46

## Test plan

- [x] Run `bun run db:push` to apply new schema
- [x] `!play` → wait a few minutes → `!stop` → `!profile` should show real minutes
- [x] Leave voice channel without `!stop` — session should end automatically
- [x] Restart bot — orphaned sessions should be cleaned up in logs
- [x] Verify `bun run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)