### PR TITLE
feat: add guild playback API endpoints

### DIFF
--- a/src/controllers/GuildController.ts
+++ b/src/controllers/GuildController.ts
@@ -1,0 +1,150 @@
+import type { Client, VoiceChannel } from "discord.js";
+import { ChannelType } from "discord.js";
+import type { IAudioService } from "@/services/interfaces/IAudioService";
+import type { IStationService } from "@/services/interfaces/IStationService";
+
+interface GuildAudioResponse {
+  isPlaying: boolean;
+  currentStation: { id: number; name: string } | null;
+  channelId: string | null;
+  channelName: string | null;
+  listenerCount: number;
+  connectedSince: string | null;
+}
+
+interface VoiceChannelInfo {
+  id: string;
+  name: string;
+}
+
+interface GuildStatusResponse {
+  guildId: string;
+  name: string;
+  iconUrl: string | null;
+  memberCount: number;
+  audio: GuildAudioResponse;
+  voiceChannels: VoiceChannelInfo[];
+}
+
+export class GuildController {
+  constructor(
+    private readonly audioService: IAudioService,
+    private readonly stationService: IStationService,
+    private readonly client: Client,
+  ) {}
+
+  async getGuilds() {
+    const guilds: GuildStatusResponse[] = [];
+
+    for (const [guildId, guild] of this.client.guilds.cache) {
+      guilds.push(await this.buildGuildStatus(guildId, guild));
+    }
+
+    return { data: guilds, status: 200 };
+  }
+
+  async getGuildStatus(guildId: string) {
+    const guild = this.client.guilds.cache.get(guildId);
+    if (!guild) {
+      return { data: { error: "Guild not found" }, status: 404 };
+    }
+
+    return { data: await this.buildGuildStatus(guildId, guild), status: 200 };
+  }
+
+  async playInGuild(guildId: string, stationId?: number, channelId?: string) {
+    if (!stationId || !channelId) {
+      return { data: { error: "stationId and channelId are required" }, status: 400 };
+    }
+
+    const guild = this.client.guilds.cache.get(guildId);
+    if (!guild) {
+      return { data: { error: "Guild not found" }, status: 404 };
+    }
+
+    const channel = guild.channels.cache.get(channelId);
+    if (!channel || channel.type !== ChannelType.GuildVoice) {
+      return { data: { error: "Voice channel not found" }, status: 404 };
+    }
+
+    const station = await this.stationService.getStationById(stationId);
+    if (!station) {
+      return { data: { error: "Station not found" }, status: 404 };
+    }
+
+    // Cleanup existing connection if any
+    if (this.audioService.hasState(guildId)) {
+      this.audioService.cleanup(guildId);
+    }
+
+    const state = await this.audioService.joinChannel(channel as VoiceChannel);
+    state.currentStationId = stationId;
+    await this.audioService.startStream(guildId, station.url);
+
+    return { data: await this.buildGuildStatus(guildId, guild), status: 200 };
+  }
+
+  async stopInGuild(guildId: string) {
+    if (!this.audioService.hasState(guildId)) {
+      return { data: { error: "No active connection in this guild" }, status: 404 };
+    }
+
+    this.audioService.cleanup(guildId);
+    return { data: { success: true }, status: 200 };
+  }
+
+  async stopAll() {
+    this.audioService.cleanupAll();
+    return { data: { success: true }, status: 200 };
+  }
+
+  private async buildGuildStatus(
+    guildId: string,
+    guild: { name: string; iconURL: (opts?: object) => string | null; memberCount: number; channels: { cache: Map<string, { id: string; name: string; type: ChannelType; members?: Map<string, unknown> }> } },
+  ): Promise<GuildStatusResponse> {
+    const state = this.audioService.getState(guildId);
+
+    let currentStation: { id: number; name: string } | null = null;
+    if (state?.currentStationId) {
+      const station = await this.stationService.getStationById(state.currentStationId);
+      if (station) {
+        currentStation = { id: station.id, name: station.name };
+      }
+    }
+
+    let channelName: string | null = null;
+    let listenerCount = 0;
+    if (state?.channelId) {
+      const channel = guild.channels.cache.get(state.channelId);
+      if (channel) {
+        channelName = channel.name;
+        if (channel.members && channel.members instanceof Map) {
+          listenerCount = Math.max(0, channel.members.size - 1); // exclude bot
+        }
+      }
+    }
+
+    const voiceChannels: VoiceChannelInfo[] = [];
+    for (const [, channel] of guild.channels.cache) {
+      if (channel.type === ChannelType.GuildVoice) {
+        voiceChannels.push({ id: channel.id, name: channel.name });
+      }
+    }
+
+    return {
+      guildId,
+      name: guild.name,
+      iconUrl: guild.iconURL({ size: 128 }),
+      memberCount: guild.memberCount,
+      audio: {
+        isPlaying: state?.isPlaying ?? false,
+        currentStation,
+        channelId: state?.channelId ?? null,
+        channelName,
+        listenerCount,
+        connectedSince: state?.connectedSince?.toISOString() ?? null,
+      },
+      voiceChannels,
+    };
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import { RankCommand } from "@/commands/RankCommand";
 import { GlobalRankCommand } from "@/commands/GlobalRankCommand";
 import { CommandController } from "@/controllers/CommandController";
 import { StationController } from "@/controllers/StationController";
+import { GuildController } from "@/controllers/GuildController";
 import { HealthService } from "@/services/HealthService";
 import { ApiServer } from "@/server/ApiServer";
 import { botLogger, seedLogger } from "@/utils/logger";
@@ -65,8 +66,15 @@ const sessionService = new SessionService(sessionRepository, profileService);
 audioService.setSessionService(sessionService);
 const healthService = new HealthService(client, db, audioService);
 const stationController = new StationController(stationService);
+const guildController = new GuildController(audioService, stationService, client);
 const apiServer = config.api.enabled
-  ? new ApiServer(healthService, stationController, config.api.port, config.api.key || undefined)
+  ? new ApiServer(
+      healthService,
+      stationController,
+      guildController,
+      config.api.port,
+      config.api.key || undefined,
+    )
   : null;
 
 // Initialize controller and register commands

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -10,6 +10,7 @@ export interface GuildAudioState {
   isPlaying: boolean;
   currentStationId: number | null;
   channelId: string;
+  connectedSince: Date;
 }
 
 export interface CommandContext {

--- a/src/server/ApiServer.ts
+++ b/src/server/ApiServer.ts
@@ -3,6 +3,7 @@ import { cors } from "@elysiajs/cors";
 import { healthLogger } from "@/utils/logger";
 import type { IHealthService } from "@/services/interfaces/IHealthService";
 import type { StationController } from "@/controllers/StationController";
+import type { GuildController } from "@/controllers/GuildController";
 
 export class ApiServer {
   private app: Elysia;
@@ -10,6 +11,7 @@ export class ApiServer {
   constructor(
     private readonly healthService: IHealthService,
     private readonly stationController: StationController,
+    private readonly guildController: GuildController,
     private readonly port: number,
     private readonly apiKey?: string
   ) {
@@ -36,6 +38,11 @@ export class ApiServer {
           "/api/stations",
           "/api/stations/:id",
           "/api/stations/:id/default",
+          "/api/guilds",
+          "/api/guilds/:guildId/status",
+          "/api/guilds/:guildId/play",
+          "/api/guilds/:guildId/stop",
+          "/api/guilds/stop-all",
         ],
       }))
       .get("/health", async ({ set }) => {
@@ -74,6 +81,37 @@ export class ApiServer {
       .put("/api/stations/:id/default", async ({ params, set }) => {
         const id = parseInt(params.id, 10);
         const result = await this.stationController.setDefault(id);
+        set.status = result.status;
+        return result.data;
+      })
+      .get("/api/guilds", async () => {
+        const result = await this.guildController.getGuilds();
+        return result.data;
+      })
+      .post("/api/guilds/stop-all", async () => {
+        const result = await this.guildController.stopAll();
+        return result.data;
+      })
+      .get("/api/guilds/:guildId/status", async ({ params, set }) => {
+        const result = await this.guildController.getGuildStatus(params.guildId);
+        set.status = result.status;
+        return result.data;
+      })
+      .post("/api/guilds/:guildId/play", async ({ params, body, set }) => {
+        const { stationId, channelId } = body as {
+          stationId?: number;
+          channelId?: string;
+        };
+        const result = await this.guildController.playInGuild(
+          params.guildId,
+          stationId,
+          channelId,
+        );
+        set.status = result.status;
+        return result.data;
+      })
+      .post("/api/guilds/:guildId/stop", async ({ params, set }) => {
+        const result = await this.guildController.stopInGuild(params.guildId);
         set.status = result.status;
         return result.data;
       });

--- a/src/services/AudioService.ts
+++ b/src/services/AudioService.ts
@@ -35,6 +35,10 @@ export class AudioService implements IAudioService {
     return this.guildStates.has(guildId);
   }
 
+  getAllActiveStates(): Array<{ guildId: string; state: GuildAudioState }> {
+    return Array.from(this.guildStates.entries()).map(([guildId, state]) => ({ guildId, state }));
+  }
+
   async joinChannel(channel: VoiceBasedChannel): Promise<GuildAudioState> {
     const guildId = channel.guild.id;
 
@@ -61,6 +65,7 @@ export class AudioService implements IAudioService {
       isPlaying: false,
       currentStationId: null,
       channelId: channel.id,
+      connectedSince: new Date(),
     };
 
     this.guildStates.set(guildId, state);

--- a/src/services/interfaces/IAudioService.ts
+++ b/src/services/interfaces/IAudioService.ts
@@ -5,6 +5,7 @@ import type { ISessionService } from "./ISessionService";
 export interface IAudioService {
   getState(guildId: string): GuildAudioState | undefined;
   hasState(guildId: string): boolean;
+  getAllActiveStates(): Array<{ guildId: string; state: GuildAudioState }>;
   joinChannel(channel: VoiceBasedChannel): Promise<GuildAudioState>;
   startStream(guildId: string, streamUrl: string): Promise<void>;
   stopStream(guildId: string): void;


### PR DESCRIPTION
## Summary

- Add `GuildController` with 5 endpoints for remote guild playback control (`GET /api/guilds`, `GET /api/guilds/:guildId/status`, `POST /api/guilds/:guildId/play`, `POST /api/guilds/:guildId/stop`, `POST /api/guilds/stop-all`)
- Add `connectedSince` field to `GuildAudioState` and `getAllActiveStates()` to `IAudioService`/`AudioService`
- Wire `GuildController` into DI composition root and `ApiServer` routes

Closes #45

## Test plan

- [x] Start bot with `bun run dev`, verify `GET /api/guilds` returns guild list with voice channels and audio state
- [x] Join bot to a voice channel via `!play`, verify `GET /api/guilds/:guildId/status` shows `isPlaying: true`
- [x] Test `POST /api/guilds/:guildId/play` with valid stationId/channelId
- [x] Test `POST /api/guilds/:guildId/stop` stops playback
- [x] Test `POST /api/guilds/stop-all` disconnects from all guilds
- [x] Verify `bun run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)