### PR TITLE
feat: session-based listening time tracking & guild playback API

### DIFF
--- a/src/controllers/GuildController.ts
+++ b/src/controllers/GuildController.ts
@@ -1,6 +1,7 @@
 import type { Client, VoiceChannel } from "discord.js";
 import { ChannelType } from "discord.js";
 import type { IAudioService } from "@/services/interfaces/IAudioService";
+import type { ISessionService } from "@/services/interfaces/ISessionService";
 import type { IStationService } from "@/services/interfaces/IStationService";
 
 interface GuildAudioResponse {
@@ -30,7 +31,8 @@ export class GuildController {
   constructor(
     private readonly audioService: IAudioService,
     private readonly stationService: IStationService,
-    private readonly client: Client,
+    private readonly sessionService: ISessionService,
+    private readonly client: Client
   ) {}
 
   async getGuilds() {
@@ -81,6 +83,19 @@ export class GuildController {
     state.currentStationId = stationId;
     await this.audioService.startStream(guildId, station.url);
 
+    // Create listening sessions for users already in the voice channel
+    const voiceChannel = channel as VoiceChannel;
+    for (const [, member] of voiceChannel.members) {
+      if (!member.user.bot) {
+        await this.sessionService.startSession(guildId, member.id, stationId, {
+          userId: member.id,
+          username: member.user.username,
+          displayName: member.user.displayName,
+          avatarUrl: member.user.avatarURL(),
+        });
+      }
+    }
+
     return { data: await this.buildGuildStatus(guildId, guild), status: 200 };
   }
 
@@ -100,7 +115,17 @@ export class GuildController {
 
   private async buildGuildStatus(
     guildId: string,
-    guild: { name: string; iconURL: (opts?: object) => string | null; memberCount: number; channels: { cache: Map<string, { id: string; name: string; type: ChannelType; members?: Map<string, unknown> }> } },
+    guild: {
+      name: string;
+      iconURL: (opts?: object) => string | null;
+      memberCount: number;
+      channels: {
+        cache: Map<
+          string,
+          { id: string; name: string; type: ChannelType; members?: Map<string, unknown> }
+        >;
+      };
+    }
   ): Promise<GuildStatusResponse> {
     const state = this.audioService.getState(guildId);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,14 +66,14 @@ const sessionService = new SessionService(sessionRepository, profileService);
 audioService.setSessionService(sessionService);
 const healthService = new HealthService(client, db, audioService);
 const stationController = new StationController(stationService);
-const guildController = new GuildController(audioService, stationService, client);
+const guildController = new GuildController(audioService, stationService, sessionService, client);
 const apiServer = config.api.enabled
   ? new ApiServer(
       healthService,
       stationController,
       guildController,
       config.api.port,
-      config.api.key || undefined,
+      config.api.key || undefined
     )
   : null;
 

--- a/src/server/ApiServer.ts
+++ b/src/server/ApiServer.ts
@@ -102,11 +102,7 @@ export class ApiServer {
           stationId?: number;
           channelId?: string;
         };
-        const result = await this.guildController.playInGuild(
-          params.guildId,
-          stationId,
-          channelId,
-        );
+        const result = await this.guildController.playInGuild(params.guildId, stationId, channelId);
         set.status = result.status;
         return result.data;
       })


### PR DESCRIPTION
## Summary

- Adds `listening_sessions` table to track real listening duration per user
- Replaces hardcoded 1-min-per-command XP with actual minutes listened
- Sessions are created on `!play` and on API `POST /api/guilds/:guildId/play`
- Sessions end on `!stop`, voice leave, bot disconnect, or shutdown
- Orphaned sessions from previous bot runs are cleaned up on startup
- API play endpoint creates sessions for all users already in the voice channel

Closes #38
Closes #49

## Test plan

- [x] Run `bun run db:push` to apply new schema
- [x] `!play` → wait a few minutes → `!stop` → `!profile` should show real minutes
- [x] `POST /api/guilds/:guildId/play` → users in channel get sessions created
- [x] Leave voice channel without `!stop` — session should end automatically
- [x] Restart bot — orphaned sessions should be cleaned up in logs
- [x] Verify `bun run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)